### PR TITLE
fix typo

### DIFF
--- a/cat-config-linux/generate_hash.sh
+++ b/cat-config-linux/generate_hash.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 
-local catapult_src=$1
+local catapult_server_src=$1
 local generation_hash_path=$PWD/generation_hash.txt
 
 ## Run address tool


### PR DESCRIPTION
There was a typo in generate_hash.sh file